### PR TITLE
Switch to parking_lot mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "3.2", default-features = fa
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 lru = "0.12"
-spin = "0.9.8"
+parking_lot = "0.12.1"
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,7 +1,7 @@
 use ethereum_types::{Bloom, H160, H256, H64, U256};
 use lru::LruCache;
 use sha3::{Digest, Keccak256};
-use spin::Mutex;
+use parking_lot::Mutex;
 use std::sync::OnceLock;
 
 use crate::Bytes;


### PR DESCRIPTION
- Switch mutex to parking lot, so if in the off chance there's contention, spin doesn't keep it up, as keccak hashes are expensive.
